### PR TITLE
Refactor: 불필요한 import문 자동생성되지 않도록 svgr 옵션 추가

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint --max-warnings 0",
     "generate:component": "turbo gen react-component",
-    "svgr": "svgr --out-dir src/icons/src src/icons/assets --typescript --icon",
+    "svgr": "svgr --out-dir src/icons/src src/icons/assets --typescript --icon --jsx-runtime automatic",
     "optimize-svg": "pnpm exec svgo -f src/icons/assets -o src/icons/assets",
     "build": "npm run optimize-svg",
     "storybook": "storybook dev -p 6006",

--- a/packages/design-system/src/icons/src/SymbolLogo.tsx
+++ b/packages/design-system/src/icons/src/SymbolLogo.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import type { SVGProps } from 'react';
 const SvgSymbolLogo = (props: SVGProps<SVGSVGElement>) => (
   <svg


### PR DESCRIPTION
## 📌 Summary

> - #41 

import문 자동생성되지 않도록 svgr 옵션 추가

## 📚 Tasks

- svgr로 svg 파일 변환할때 생기는 필요없는 import문이 생기지 않도록 옵션을 추가합니다.


## 👀 To Reviewer
- design-system의 package.json 파일에서 svgr 관련 스크립트에 --jsx-runtime automatic 옵션을 추가하여, jsxRuntime 설정을 자동으로 적용

## 📸 Screenshot
pnpm svgr 실행 후 변환된 tsx 파일에 `import * as React from 'react';` 안뜸!!

<img width="454" alt="스크린샷 2025-01-09 오후 7 45 03" src="https://github.com/user-attachments/assets/192fdb6d-6136-481e-b4b2-050564660f68" />

