### PR TITLE
Feat(client): 공연 더보기 페이지 퍼블리싱

### DIFF
--- a/apps/client/src/pages/my/page/confeti-detail.css.ts
+++ b/apps/client/src/pages/my/page/confeti-detail.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'grid',
-  gridTemplateColumns: '1fr 1fr 1fr',
+  gridTemplateColumns: 'repeat(3, 1fr)',
   padding: '2.4rem 2rem',
   gridColumnGap: '1.75rem',
   gridRowGap: '3rem',

--- a/apps/client/src/pages/my/page/confeti-detail.css.ts
+++ b/apps/client/src/pages/my/page/confeti-detail.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr 1fr',
+  padding: '2.4rem 2rem',
+  gridColumnGap: '1.75rem',
+  gridRowGap: '3rem',
+});

--- a/apps/client/src/pages/my/page/confeti-detail.tsx
+++ b/apps/client/src/pages/my/page/confeti-detail.tsx
@@ -1,9 +1,20 @@
-import { Header } from '@confeti/design-system';
+import { FestivalCard, Header } from '@confeti/design-system';
+import { PERFORMANCE_DATA } from '@shared/mocks/performance-data';
+import * as styles from './confeti-detail.css';
 
 const ConfetiDetail = () => {
   return (
     <>
-      <Header variant="detail" title="마이페이지" />
+      <Header variant="detail" title="My Confeti" />
+      <div className={styles.container}>
+        {PERFORMANCE_DATA.data.performances.map((performance) => (
+          <FestivalCard
+            key={performance.performanceId}
+            title={performance.title}
+            imageSrc={performance.posterUrl}
+          />
+        ))}
+      </div>
     </>
   );
 };

--- a/apps/client/src/pages/my/page/confeti-detail.tsx
+++ b/apps/client/src/pages/my/page/confeti-detail.tsx
@@ -1,0 +1,11 @@
+import { Header } from '@confeti/design-system';
+
+const ConfetiDetail = () => {
+  return (
+    <>
+      <Header variant="detail" title="마이페이지" />
+    </>
+  );
+};
+
+export default ConfetiDetail;

--- a/apps/client/src/shared/constants/path.ts
+++ b/apps/client/src/shared/constants/path.ts
@@ -1,4 +1,5 @@
 export const routePath = {
   ROOT: '/',
   MY: '/my',
+  MYCONFETI: '/my-confeti',
 } as const;

--- a/apps/client/src/shared/mocks/performance-data.ts
+++ b/apps/client/src/shared/mocks/performance-data.ts
@@ -1,0 +1,48 @@
+export const PERFORMANCE_DATA = {
+  data: {
+    performances: [
+      {
+        performanceId: 1,
+        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        posterUrl:
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
+      },
+      {
+        performanceId: 2,
+        title: '2024 위버스 콘 페스티벌',
+        posterUrl:
+          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSUYECrN1uLKcS2DYqamPLikzzmusDz15fFBg&s',
+      },
+      {
+        performanceId: 3,
+        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        posterUrl:
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
+      },
+      {
+        performanceId: 4,
+        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        posterUrl:
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
+      },
+      {
+        performanceId: 5,
+        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        posterUrl:
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
+      },
+      {
+        performanceId: 6,
+        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        posterUrl:
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
+      },
+      {
+        performanceId: 7,
+        title: '2025 검정치마 단독공연＂SONGS TO BRING YOU HOME＂',
+        posterUrl:
+          'https://ticketimage.interpark.com/Play/image/large/25/25000084_p.gif',
+      },
+    ],
+  },
+} as const;

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -2,3 +2,6 @@ import { lazy } from 'react';
 
 export const HomePage = lazy(() => import('@pages/home/page/home'));
 export const MyPage = lazy(() => import('@pages/my/page/my'));
+export const MyConfetiPage = lazy(
+  () => import('@pages/my/page/confeti-detail'),
+);

--- a/apps/client/src/shared/router/router.tsx
+++ b/apps/client/src/shared/router/router.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import GlobalLayout from './global-layout';
-import { HomePage, MyPage } from './lazy';
+import { HomePage, MyConfetiPage, MyPage } from './lazy';
 import { routePath } from '@shared/constants/path';
 
 export default function Router() {
@@ -11,6 +11,7 @@ export default function Router() {
         <Route element={<GlobalLayout />}>
           <Route path={routePath.ROOT} element={<HomePage />} />
           <Route path={routePath.MY} element={<MyPage />} />
+          <Route path={routePath.MYCONFETI} element={<MyConfetiPage />} />
         </Route>
       </Routes>
     </Suspense>

--- a/packages/design-system/src/components/festival-card/festival-card.css.ts
+++ b/packages/design-system/src/components/festival-card/festival-card.css.ts
@@ -6,14 +6,14 @@ export const card = style({
   ...themeVars.display.flexColumn,
   alignItems: 'center',
   gap: '0.8rem',
-  width: '10rem',
+  width: '100%',
   position: 'relative',
 });
 
 export const poster = recipe({
   base: {
     width: '100%',
-    height: '14.2rem',
+    height: '80%',
     position: 'relative',
   },
   variants: {


### PR DESCRIPTION
## 📌 Summary

 > - #77 )

공연 더보기 페이지를 퍼블리싱 했어요.

## 📚 Tasks

- my confeti 페이지 라우팅 추가
- 페이지 퍼블리싱
- festival card 사이즈 조정

## 👀 To Reviewer

반응형 고려하여 festival card의 height 수정하였습니다.
명세서 참고하여 PERFORMANCE_DATA 임시로 설정했습니다.

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/41739e28-fefb-4463-9809-fadbdec49839)
