### PR TITLE
Fix(design-system): 페스티벌 카드 모바일 화면 깨짐 해결

### DIFF
--- a/apps/client/src/shared/mocks/performance-data.ts
+++ b/apps/client/src/shared/mocks/performance-data.ts
@@ -3,7 +3,7 @@ export const PERFORMANCE_DATA = {
     performances: [
       {
         performanceId: 1,
-        title: 'TONE STUDIO LIVE 〈고고학(GOGOHAWK)〉',
+        title: '인천 펜타포트 락 페스티벌 2025',
         posterUrl:
           'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
       },
@@ -11,7 +11,7 @@ export const PERFORMANCE_DATA = {
         performanceId: 2,
         title: '2024 위버스 콘 페스티벌',
         posterUrl:
-          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSUYECrN1uLKcS2DYqamPLikzzmusDz15fFBg&s',
+          'https://cdnticket.melon.co.kr/resource/image/upload/product/2024/12/2024122617060697685b42-e726-4421-b1e0-eb803e95bd7c.jpg/melon/resize/180x254/strip/true/quality/90/optimize',
       },
       {
         performanceId: 3,

--- a/packages/design-system/src/components/festival-card/festival-card.css.ts
+++ b/packages/design-system/src/components/festival-card/festival-card.css.ts
@@ -45,7 +45,7 @@ export const icon = style({
 export const title = style([
   themeVars.fontStyles.body4_m_13,
   {
-    width: '100%',
+    width: '10rem',
     textAlign: 'center',
     color: themeVars.color.black,
     overflow: 'hidden',


### PR DESCRIPTION
## 📌 Summary

> - #119 

페스티벌 카드 모바일 화면 깨짐 이슈를 해결했어요

## 📚 Tasks

- festival-card 컴포넌트 title에 width값 지정

## 👀 To Reviewer

반응형 대응을 위해 title에 width에 고정값을 넣지 않고, `wordBreak: keep-all`을 지정해주었는데 해당 부분 때문에 이슈가 발생했습니다. width에 10rem을 지정해주어서 해결했습니다!

이슈를 해결함으로써 스크린크기에 따라 이미지 크기는 늘어나지만, title은 width값이 고정되어있어서 적용되지 않습니다. 
하지만 title의 정확한 정보(부자연스러운 띄어쓰기)를 제공하기 위해서는 어쩔 수 없는 것 같아요. UX와 연결되는 부분이기도 하고요 !