### PR TITLE
Feat(client): 페스티벌 추가 안내 페이지 구현

### DIFF
--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
@@ -24,6 +24,7 @@ export const icon = style({
 export const description = style({
   ...themeVars.fontStyles.body3_m_14,
   color: themeVars.color.gray500,
+  lineHeight: '150%',
 });
 
 export const button = style({

--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
@@ -7,7 +7,6 @@ export const container = style({
   top: '50%',
   left: '50%',
   width: '100%',
-  padding: '8rem 2rem',
   gap: '2.4rem',
   transform: 'translate(-50%, -50%)',
 });

--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.css.ts
@@ -1,0 +1,32 @@
+import { style } from '@vanilla-extract/css';
+import { themeVars } from '@confeti/design-system/styles';
+
+export const container = style({
+  ...themeVars.display.flexColumnCenter,
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: '100%',
+  padding: '8rem 2rem',
+  gap: '2.4rem',
+  transform: 'translate(-50%, -50%)',
+});
+
+export const iconDescriptionWrapper = style({
+  ...themeVars.display.flexColumnCenter,
+  gap: '2rem',
+});
+
+export const icon = style({
+  width: '5rem',
+  height: '5rem',
+});
+
+export const description = style({
+  ...themeVars.fontStyles.body3_m_14,
+  color: themeVars.color.gray500,
+});
+
+export const button = style({
+  width: '17.6rem',
+});

--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.tsx
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@confeti/design-system';
+import { routePath } from '@shared/constants/path';
+import { IcFestivalGray } from '@confeti/design-system/icons';
+import * as styles from './empty-festival-section.css';
+
+const EmptyFestivalSection = () => {
+  const navigate = useNavigate();
+
+  const handleAddFestivalClick = () => {
+    navigate(routePath.SEARCH);
+  };
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.iconDescriptionWrapper}>
+        <IcFestivalGray className={styles.icon} />
+        <h2 className={styles.description}>
+          페스티벌을 추가해
+          <br />
+          나만의 타임테이블을 등록해보세요
+        </h2>
+      </div>
+      <Button
+        className={styles.button}
+        text="페스티벌 추가하기"
+        onClick={handleAddFestivalClick}
+      />
+    </section>
+  );
+};
+
+export default EmptyFestivalSection;

--- a/apps/client/src/pages/time-table/components/empty/empty-festival-section.tsx
+++ b/apps/client/src/pages/time-table/components/empty/empty-festival-section.tsx
@@ -16,11 +16,11 @@ const EmptyFestivalSection = () => {
     <section className={styles.container}>
       <div className={styles.iconDescriptionWrapper}>
         <IcFestivalGray className={styles.icon} />
-        <h2 className={styles.description}>
+        <h1 className={styles.description}>
           페스티벌을 추가해
           <br />
           나만의 타임테이블을 등록해보세요
-        </h2>
+        </h1>
       </div>
       <Button
         className={styles.button}

--- a/apps/client/src/pages/time-table/page/empty/empty-festival.tsx
+++ b/apps/client/src/pages/time-table/page/empty/empty-festival.tsx
@@ -1,0 +1,7 @@
+import EmptyFestivalSection from '../../components/empty/empty-festival-section';
+
+const EmptyFestival = () => {
+  return <EmptyFestivalSection />;
+};
+
+export default EmptyFestival;

--- a/apps/client/src/pages/time-table/page/time-table-layout.tsx
+++ b/apps/client/src/pages/time-table/page/time-table-layout.tsx
@@ -1,0 +1,7 @@
+import { Outlet } from 'react-router-dom';
+
+const TimeTableLayout = () => {
+  return <Outlet />;
+};
+
+export default TimeTableLayout;

--- a/apps/client/src/shared/constants/path.ts
+++ b/apps/client/src/shared/constants/path.ts
@@ -13,4 +13,5 @@ export const routePath = {
   FESTIVAL: '/festival-detail/:festivalId',
   // time-table
   TIME_TABLE: '/timetable',
+  TIME_TABLE_EMPTY_FESTIVAL: '/empty-festival',
 } as const;

--- a/apps/client/src/shared/constants/path.ts
+++ b/apps/client/src/shared/constants/path.ts
@@ -12,6 +12,6 @@ export const routePath = {
   CONCERT: '/concert-detail/:concertId',
   FESTIVAL: '/festival-detail/:festivalId',
   // time-table
-  TIME_TABLE: '/timetable',
-  TIME_TABLE_EMPTY_FESTIVAL: '/empty-festival',
+  TIME_TABLE_OUTLET: '/timetable',
+  TIME_TABLE_EMPTY_FESTIVAL: 'empty-festival',
 } as const;

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -24,6 +24,9 @@ export const FestivalDetailPage = lazy(
 export const TimeTable = lazy(
   () => import('@pages/time-table/page/time-table'),
 );
+export const TimeTableLayout = lazy(
+  () => import('@pages/time-table/page/time-table-layout'),
+);
 export const EmptyFestivalPage = lazy(
   () => import('@pages/time-table/page/empty/empty-festival'),
 );

--- a/apps/client/src/shared/router/lazy.ts
+++ b/apps/client/src/shared/router/lazy.ts
@@ -24,3 +24,6 @@ export const FestivalDetailPage = lazy(
 export const TimeTable = lazy(
   () => import('@pages/time-table/page/time-table'),
 );
+export const EmptyFestivalPage = lazy(
+  () => import('@pages/time-table/page/empty/empty-festival'),
+);

--- a/apps/client/src/shared/router/router.tsx
+++ b/apps/client/src/shared/router/router.tsx
@@ -12,6 +12,7 @@ import {
   RequireLoginPage,
   MyProfilePage,
   TimeTable,
+  EmptyFestivalPage,
 } from './lazy';
 import { routePath } from '@shared/constants/path';
 import { createProtectedRoute } from './protected-route';
@@ -49,6 +50,10 @@ export default function Router() {
           <Route path={routePath.CONCERT} element={<ConcertDetailPage />} />
           <Route path={routePath.FESTIVAL} element={<FestivalDetailPage />} />
           <Route path={routePath.TIME_TABLE} element={<TimeTable />} />
+          <Route
+            path={routePath.TIME_TABLE_EMPTY_FESTIVAL}
+            element={<EmptyFestivalPage />}
+          />
         </Route>
       </Routes>
     </Suspense>

--- a/apps/client/src/shared/router/router.tsx
+++ b/apps/client/src/shared/router/router.tsx
@@ -9,7 +9,6 @@ import {
   MyArtistPage,
   MyPage,
   SearchPage,
-  AddFestivalPage,
   RequireLoginPage,
   MyProfilePage,
   TimeTable,

--- a/apps/client/src/shared/router/router.tsx
+++ b/apps/client/src/shared/router/router.tsx
@@ -13,6 +13,7 @@ import {
   MyProfilePage,
   TimeTable,
   EmptyFestivalPage,
+  TimeTableLayout,
 } from './lazy';
 import { routePath } from '@shared/constants/path';
 import { createProtectedRoute } from './protected-route';
@@ -49,11 +50,18 @@ export default function Router() {
           <Route path={routePath.SEARCH} element={<SearchPage />} />
           <Route path={routePath.CONCERT} element={<ConcertDetailPage />} />
           <Route path={routePath.FESTIVAL} element={<FestivalDetailPage />} />
-          <Route path={routePath.TIME_TABLE} element={<TimeTable />} />
+
+          {/* time-table 중첩 라우팅 */}
           <Route
-            path={routePath.TIME_TABLE_EMPTY_FESTIVAL}
-            element={<EmptyFestivalPage />}
-          />
+            path={routePath.TIME_TABLE_OUTLET}
+            element={<TimeTableLayout />}
+          >
+            <Route path="" element={<TimeTable />} />
+            <Route
+              path={routePath.TIME_TABLE_EMPTY_FESTIVAL}
+              element={<EmptyFestivalPage />}
+            />
+          </Route>
         </Route>
       </Routes>
     </Suspense>


### PR DESCRIPTION
## 📌 Summary

- #102 

## 📚 Tasks

- 페스티벌 추가 안내 페이지를 구현하였습니다.

## 👀 To Reviewer
`line height` 적용 아직도 안 되네요... 임의로 설정해둘까요? @m2na7 

### 네이밍 공모전
추가된 페스티벌이 없을 때 나오는 안내 페이지인데 우선 컴포넌트 폴더 이름을` empty`로 해놓았습니다. 혹시 더 좋은 네이밍이 있다면 추천해주세요... 🥲 컴포넌트 이름은 `empty-festival-section` 인데 `empty-festival `보다 더 좋은 게 있다면 또 추천 부탁드립니다,, ㅠㅠ

경품: 추파춥스 1개 ^^ !!!;;

## 📸 Screenshot

https://github.com/user-attachments/assets/5990cf54-b368-4fe1-aa19-d2c898f95157

