### PR TITLE
Fix: (QA/1) 스타일 깨지게 적용되는 부분 수정

### DIFF
--- a/packages/design-system/src/components/navigation/navigation.tsx
+++ b/packages/design-system/src/components/navigation/navigation.tsx
@@ -46,6 +46,7 @@ const NavItem = ({ index, children }: ItemProps) => {
 
   return (
     <button
+      key={activeTab}
       className={styles.list({ active: activeTab === index })}
       onClick={() => setActiveTab(index)}
     >


### PR DESCRIPTION
## 📌 Summary

> - #114 


## 📚 Tasks

- 스타일 깨지게 적용되는 부분 수정
첫번째 렌더링시에는 잘 보여지나, 여러번 클릭시 스타일이 깨지는 걸로 보아 캐시된 스타일이 예정대로 적용되지 않는 문제라고 추측되어 NavItem 버튼에 key를 추가하여 상태 변경시 리렌더링하도록 해줬다.
```
<button
      key={activeTab} 
    >
```
![KakaoTalk_Photo_2025-01-19-03-03-22](https://github.com/user-attachments/assets/3d6114ee-0cdc-41c8-8186-354162802d6e)

