### PR TITLE
Feat(client): 검색 페이지 목록에서 공연 상세 페이지로 라우팅

### DIFF
--- a/apps/client/src/pages/confeti/components/summary.tsx
+++ b/apps/client/src/pages/confeti/components/summary.tsx
@@ -49,9 +49,9 @@ const Summary = ({
             <div className={styles.title}>
               <div className={styles.titleLeft}>{title}</div>
               {isFavorite ? (
-                <BtnHeartFilled24 width={24} />
+                <BtnHeartFilled24 width={24} height={24} />
               ) : (
-                <BtnHeartDefault24 width={24} />
+                <BtnHeartDefault24 width={24} height={24} />
               )}
             </div>
             <div className={styles.subtitle}>{subtitle}</div>

--- a/apps/client/src/pages/search/components/performance-info.css.ts
+++ b/apps/client/src/pages/search/components/performance-info.css.ts
@@ -39,6 +39,7 @@ export const title = style({
   whiteSpace: 'normal',
   wordBreak: 'keep-all',
   overflowWrap: 'break-word',
+  cursor: 'pointer',
 });
 
 export const infoRow = style({
@@ -59,6 +60,7 @@ export const infoText = style({
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
+  cursor: 'pointer',
 });
 
 export const heartIcon = style({

--- a/apps/client/src/pages/search/components/performance-info.tsx
+++ b/apps/client/src/pages/search/components/performance-info.tsx
@@ -5,8 +5,11 @@ import {
   IcPlaceGray14,
 } from '@confeti/design-system/icons';
 import * as styles from './performance-info.css';
+import { useNavigate } from 'react-router-dom';
 
 interface PerformanceInfoProps {
+  type?: string;
+  performanceId: number;
   posterUrl: string;
   title: string;
   performanceAt: string;
@@ -15,19 +18,37 @@ interface PerformanceInfoProps {
 }
 
 const PerformanceInfo = ({
+  performanceId,
   posterUrl,
   title,
   performanceAt,
   area,
   isFavorite,
+  type,
 }: PerformanceInfoProps) => {
+  const navigate = useNavigate();
+
+  const handleNavigation = () => {
+    const path =
+      type === 'concert'
+        ? `/concert-detail/${performanceId}`
+        : `/festival-detail/${performanceId}`;
+    navigate(path);
+  };
   return (
     <div className={styles.container}>
       <div className={styles.wrapper}>
-        <img src={posterUrl} alt={title} className={styles.poster} />
+        <img
+          src={posterUrl}
+          alt={title}
+          className={styles.poster}
+          onClick={handleNavigation}
+        />
 
         <div className={styles.textSection}>
-          <p className={styles.title}>{title}</p>
+          <p className={styles.title} onClick={handleNavigation}>
+            {title}
+          </p>
 
           <div className={styles.infoRow}>
             <IcTimeGray14 className={styles.infoIcon} />

--- a/apps/client/src/pages/search/components/performance-section.tsx
+++ b/apps/client/src/pages/search/components/performance-section.tsx
@@ -28,6 +28,7 @@ const PerformanceSection = ({ performances }: PerformanceSectionProps) => {
       {performances.map((performance) => (
         <PerformanceInfo
           key={performance.performanceId}
+          performanceId={performance.performanceId}
           title={performance.title}
           performanceAt={performance.performanceAt}
           posterUrl={performance.posterUrl}

--- a/apps/client/src/pages/search/components/title.tsx
+++ b/apps/client/src/pages/search/components/title.tsx
@@ -5,7 +5,7 @@ interface TitleProps {
 }
 
 const Title = ({ text }: TitleProps) => {
-  return <h2 className={styles.title}>{text}</h2>;
+  return <p className={styles.title}>{text}</p>;
 };
 
 export default Title;


### PR DESCRIPTION
## 📌 Summary

> - #112 

검색 페이지 내에서 검색결과 - 예정된 공연 카드 클릭시 id 값에 맞는 게시물(콘서트or페스티벌)로 이동하는 기능을 구현했습니다.

## 📚 Tasks

- 검색 페이지 내 공연 상세보기 기능 구현

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

## 📸 Screenshot


https://github.com/user-attachments/assets/e16c2cdf-4f0f-401a-8ef2-2c56cbabdb86
