### PR TITLE
Fix(client): 페스티벌 추가 페이지 기능 수정

### DIFF
--- a/apps/client/src/pages/time-table/hooks/use-festival-selection.ts
+++ b/apps/client/src/pages/time-table/hooks/use-festival-selection.ts
@@ -20,18 +20,17 @@ const useFestivalSelection = () => {
     });
   };
 
-  const canAddFestival = selectedFestivals.length < MAX_SELECTIONS;
-
-  const handleFestivalClick = (festivalId: number, isSelected: boolean) =>
-    isSelected
-      ? removeSelect(festivalId)
-      : canAddFestival
-        ? addSelect(festivalId)
-        : showToast();
+  const handleFestivalClick = (festivalId: number, isSelected: boolean) => {
+    if (isSelected) {
+      removeSelect(festivalId);
+    } else {
+      addSelect(festivalId);
+    }
+  };
 
   return {
     selectedFestivals,
-    canAddFestival,
+    showToast,
     handleFestivalClick,
   };
 };

--- a/apps/client/src/pages/time-table/page/add-festival.tsx
+++ b/apps/client/src/pages/time-table/page/add-festival.tsx
@@ -2,11 +2,19 @@ import { Button, FestivalCard, Header } from '@confeti/design-system';
 import { PERFORMANCE_DATA } from '@shared/mocks/performance-data';
 import * as styles from './add-festival.css';
 import useFestivalSelection from '../hooks/use-festival-selection';
+
+const MAX_SELECTIONS = 3;
+
 const AddFestival = () => {
-  const { selectedFestivals, handleFestivalClick } = useFestivalSelection();
+  const { selectedFestivals, handleFestivalClick, showToast } =
+    useFestivalSelection();
 
   const handleAddClick = () => {
-    // 타임테이블에 추가되는 로직 작성 예정
+    if (selectedFestivals.length > MAX_SELECTIONS) {
+      showToast();
+    } else {
+      // 타임테이블에 추가되는 로직 작성 예정
+    }
   };
 
   return (

--- a/packages/design-system/src/components/festival-card/festival-card.tsx
+++ b/packages/design-system/src/components/festival-card/festival-card.tsx
@@ -24,6 +24,7 @@ const FestivalCard = ({
   onSelectChange,
   id,
   type,
+  onClick,
 }: FestivalCardProps) => {
   const [internalSelected, setInternalSelected] = useState(isSelected);
   const navigate = useNavigate();
@@ -39,6 +40,10 @@ const FestivalCard = ({
 
     if (onSelectChange) {
       onSelectChange(title, toggledSelected);
+    }
+
+    if (onClick) {
+      onClick();
     }
   };
 


### PR DESCRIPTION
## 📌 Summary

> - #142 

페스티벌 추가하기 페이지 내의 toast 띄우는 로직을 수정합니다.

## 📚 Tasks

- 추가하기 버튼 클릭시 toast 띄우기

## 👀 To Reviewer

- 기존에는 페스티벌 카드를 4개부터는 선택조차 못하도록 막고 토스트를 띄웠었는데
- 선택은 가능하되, 4개 이상 선택 후 추가하기 버튼을 누르면 토스트를 띄우는 것으로 수정하였습니다.


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/01d59ec6-2744-4470-a659-3f33e8f6a483)
