### PR TITLE
Fix(client, design-system): 페스티벌 추가페이지 스타일 에러 해결

### DIFF
--- a/apps/client/src/pages/time-table/page/add-festival.css.ts
+++ b/apps/client/src/pages/time-table/page/add-festival.css.ts
@@ -3,7 +3,8 @@ import { style } from '@vanilla-extract/css';
 
 export const wrapper = style({
   ...themeVars.display.flexColumn,
-  height: '100dvh',
+  position: 'relative',
+  width: '100%',
 });
 
 export const container = style({
@@ -17,7 +18,22 @@ export const container = style({
 });
 
 export const buttonSection = style({
+  position: 'fixed',
+  bottom: '0',
+  left: '0',
   padding: '2rem',
   height: '9rem',
+  width: '100%',
   backgroundColor: themeVars.color.white,
+});
+
+export const headerLayout = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  position: 'sticky',
+  top: '5rem',
+  left: 0,
+  padding: '0.8rem 2rem',
+  zIndex: themeVars.zIndex.bottomButton.content,
 });

--- a/apps/client/src/pages/time-table/page/add-festival.tsx
+++ b/apps/client/src/pages/time-table/page/add-festival.tsx
@@ -19,7 +19,11 @@ const AddFestival = () => {
 
   return (
     <div className={styles.wrapper}>
-      <Header variant="detail" title="페스티벌 추가하기" />
+      <Header
+        variant="detail"
+        title="페스티벌 추가하기"
+        className={styles.headerLayout}
+      />
       <div className={styles.container}>
         {PERFORMANCE_DATA.data.performances.map((performance) => {
           const isSelected = selectedFestivals.includes(

--- a/packages/design-system/src/components/header/header.tsx
+++ b/packages/design-system/src/components/header/header.tsx
@@ -1,3 +1,4 @@
+import { cn } from '../../utils';
 import {
   LogoMain,
   BtnSearchG90024,
@@ -10,9 +11,14 @@ import { useNavigate } from 'react-router-dom';
 interface HeaderProps {
   variant?: 'default' | 'detail';
   title?: string;
+  className?: string;
 }
 
-const Header = ({ variant = 'default', title = '' }: HeaderProps) => {
+const Header = ({
+  variant = 'default',
+  title = '',
+  className,
+}: HeaderProps) => {
   const navigate = useNavigate();
 
   const handleBackClick = () => {
@@ -33,7 +39,9 @@ const Header = ({ variant = 'default', title = '' }: HeaderProps) => {
 
   if (variant === 'detail') {
     return (
-      <header className={styles.container({ variant: 'detail' })}>
+      <header
+        className={cn(styles.container({ variant: 'detail' }), className)}
+      >
         <button
           className={styles.button({ variant: 'back' })}
           onClick={handleBackClick}


### PR DESCRIPTION
## 📌 Summary

> - #160 


## 📚 Tasks

- 디자인 시스템 헤더에 cn을 추가해서 className prop으로 컴포넌트의 스타일을 추가할 수 있도록 변경했습니다.
- 헤더와 하단 고정되도록 수정


## 📸 Screenshot

https://github.com/user-attachments/assets/07d613fa-431f-4a11-b8c4-74253470c883


