### PR TITLE
Fix(client): iOS에서 input창 확대 되는 이슈 해결

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -7,7 +7,10 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css"
       rel="stylesheet"
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
     <meta property="og:title" content="confeti" />
     <meta
       property="og:description"

--- a/apps/client/src/pages/search/hooks/use-search-logic.ts
+++ b/apps/client/src/pages/search/hooks/use-search-logic.ts
@@ -24,8 +24,13 @@ export const useSearchLogic = () => {
 
   const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && searchKeyword.trim()) {
-      navigate(`${routePath.SEARCH}?q=${searchKeyword}`);
-      setBarFocus(false);
+      e.preventDefault();
+      setTimeout(() => {
+        navigate(`${routePath.SEARCH}?q=${searchKeyword}`);
+        setBarFocus(false);
+        setSearchKeyword('');
+        (e.target as HTMLInputElement).blur();
+      }, 0);
     }
   };
 

--- a/apps/client/src/pages/search/page/search.tsx
+++ b/apps/client/src/pages/search/page/search.tsx
@@ -4,7 +4,6 @@ import NoticeSection from '@pages/search/components/notice-section';
 import ArtistSection from '@pages/search/components/artist-section';
 import PerformanceSection from '@pages/search/components/performance-section';
 import PerformanceCount from '@pages/search/components/performance-count-section';
-import ArtistNotFound from '@pages/search/components/artist-not-found';
 import { useSearchLogic } from '../hooks/use-search-logic';
 
 const Search = () => {
@@ -26,22 +25,16 @@ const Search = () => {
         onFocus={handleOnFocus}
         onBlur={handleOnBlur}
       />
-      {!barFocus && (
+      {!barFocus && paramsKeyword.length > 0 && (
         <>
           <main className={styles.resultSection}>
-            {paramsKeyword.length > 0 ? (
-              <>
-                <NoticeSection
-                  isMultipleArtists={artistData[0]?.isMultipleArtists}
-                />
-                <ArtistSection artist={artistData} />
-                <Spacing />
-                <PerformanceCount />
-                <PerformanceSection />
-              </>
-            ) : (
-              <ArtistNotFound />
-            )}
+            <NoticeSection
+              isMultipleArtists={artistData[0]?.isMultipleArtists}
+            />
+            <ArtistSection artist={artistData} />
+            <Spacing />
+            <PerformanceCount />
+            <PerformanceSection />
           </main>
           <Footer />
         </>

--- a/packages/design-system/src/components/search-bar/search-bar.tsx
+++ b/packages/design-system/src/components/search-bar/search-bar.tsx
@@ -62,6 +62,7 @@ export const SearchBar = ({
             onKeyDown={onKeyDown}
             onFocus={onFocus}
             onBlur={onBlur}
+            enterKeyHint="search"
           />
           {showClearBtn && (
             <SvgBtnClose


### PR DESCRIPTION
## 📌 Summary

- #122 

## 📚 Tasks

- iOS에서 Input창 눌러도 확대 안 되게 수정했습니다.
- 기존에는 엔터를 눌러도 커서가 안 꺼졌기 때문에 모바일에서 보면 검색을 해도 키보드가 내려가지 않는 이슈가 있었습니다. 이를 엔터를 치면 커서가 꺼지게끔 수정하였습니다.
- 검색할 때 사용자 경험을 위해 사용자의 키보드 `엔터` 부분이 `검색`으로 뜨게끔 기능을 추가하였습니다.

## 👀 To Reviewer
 Enter 키를 누를 때 searchKeyword가 상태로 업데이트되면서 입력 필드가 리렌더링되고 키 입력 이벤트가 두 번 처리되는 현상이 발생했습니다. 이로 인해 '데이식스'를 검색하면 '데이식스스'처럼 키 입력이 중복되는 문제가 생겼습니다 🥲

이를 `setTimeout`을 사용하여 상태 변경과 네비게이션을 이벤트 루프의 다음 단계로 분리했습니다. 또한 e.preventDefault()로 브라우저의 기본 Enter 동작을 방지하여 이벤트가 중복 실행되지 않도록 했는데요,,, 만약 다른 방식으로도 문제를 해결할 수 있는 아이디어가 있다면 피드백 부탁드립니다!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
