### PR TITLE
Feat(client): 콘서트 좋아요 추가, 삭제 api 연결

### DIFF
--- a/apps/client/src/pages/confeti/components/summary/summary.tsx
+++ b/apps/client/src/pages/confeti/components/summary/summary.tsx
@@ -14,7 +14,8 @@ interface SummaryProps {
   area: string;
   reserveAt: string;
   reservationUrl: string;
-  isFavorite: boolean; // isFavorite 추가
+  isFavorite: boolean;
+  type: 'FESTIVAL' | 'CONCERT';
 }
 
 // 날짜 및 시간 포맷팅 함수
@@ -42,11 +43,16 @@ const Summary = ({
   reserveAt,
   reservationUrl,
   isFavorite,
+  type,
 }: SummaryProps) => {
   const { mutate } = useLikeMutation();
 
-  const handleLikeFestival = (id: number, action: 'LIKE' | 'UNLIKE') => {
-    mutate({ id, action, type: 'FESTIVAL' });
+  const handleLike = (
+    id: number,
+    action: 'LIKE' | 'UNLIKE',
+    type: 'FESTIVAL' | 'CONCERT',
+  ) => {
+    mutate({ id, action, type });
   };
 
   return (
@@ -60,7 +66,7 @@ const Summary = ({
                 isFavorite={isFavorite}
                 className={styles.heartIcon}
                 onClick={() =>
-                  handleLikeFestival(id, isFavorite ? 'UNLIKE' : 'LIKE')
+                  handleLike(id, isFavorite ? 'UNLIKE' : 'LIKE', type)
                 }
               />
             </div>

--- a/apps/client/src/pages/confeti/page/concert-detail.tsx
+++ b/apps/client/src/pages/confeti/page/concert-detail.tsx
@@ -36,6 +36,7 @@ const ConcertDetailPage = () => {
         reserveAt={concert.reserveAt}
         reservationUrl={concert.reservationUrl}
         isFavorite={concert.isFavorite}
+        type="CONCERT"
       />
       <Info
         subtitle={concert.subtitle}

--- a/apps/client/src/pages/confeti/page/festival-detail.tsx
+++ b/apps/client/src/pages/confeti/page/festival-detail.tsx
@@ -39,6 +39,7 @@ const FestivalDetailPage = () => {
         reserveAt={festival.reserveAt}
         reservationUrl={festival.reservationUrl}
         isFavorite={festival.isFavorite}
+        type="FESTIVAL"
       />
       <Spacing />
       <Info

--- a/apps/client/src/shared/apis/like/like.ts
+++ b/apps/client/src/shared/apis/like/like.ts
@@ -22,4 +22,10 @@ export const deleteLikeFestival = async (festivalId: number): Promise<void> => {
   await del<BaseResponseWithoutData>(END_POINT.POST_LIKE_FESTIVAL(festivalId));
 };
 
-// TODO: postLikeConcert, deleteLikeConcert API 추가
+export const postLikeConcert = async (concertId: number): Promise<void> => {
+  await post<BaseResponseWithoutData>(END_POINT.POST_LIKE_CONCERT(concertId));
+};
+
+export const deleteLikeConcert = async (concertId: number): Promise<void> => {
+  await del<BaseResponseWithoutData>(END_POINT.POST_LIKE_CONCERT(concertId));
+};

--- a/apps/client/src/shared/constants/api.ts
+++ b/apps/client/src/shared/constants/api.ts
@@ -7,6 +7,8 @@ export const END_POINT = {
   POST_LIKE_ARTIST: (artistId: string) => `/user/favorites/artists/${artistId}`,
   POST_LIKE_FESTIVAL: (festivalId: number) =>
     `/user/favorites/festivals/${festivalId}`,
+  POST_LIKE_CONCERT: (concertId: number) =>
+    `user/favorites/concerts/${concertId}`,
   GET_FESTIVAL_DETAIL: '/performances/festivals',
   GET_CONCERT_DETAIL: '/performances/concerts',
   GET_TICKETING: '/performances/reservation',

--- a/apps/client/src/shared/hooks/use-like-mutation.ts
+++ b/apps/client/src/shared/hooks/use-like-mutation.ts
@@ -4,6 +4,8 @@ import {
   deleteLikeArtist,
   postLikeFestival,
   deleteLikeFestival,
+  postLikeConcert,
+  deleteLikeConcert,
 } from '@shared/apis/like/like';
 import { LIKE_QUERY_KEY } from '@shared/apis/like/like-queries';
 import { PERFORMANCE_QUERY_KEY } from '@shared/apis/confeti-detail/performance-queries';
@@ -74,14 +76,13 @@ export const useLikeMutation = () => {
           }
           break;
 
-        // TODO: CONCERT API 연결
-        // case 'CONCERT':
-        //   if (action === 'LIKE') {
-        //     await postLikeConcert(Number(id));
-        //   } else if (action === 'UNLIKE') {
-        //     await deleteLikeConcert(Number(id));
-        //   }
-        //   break;
+        case 'CONCERT':
+          if (action === 'LIKE') {
+            await postLikeConcert(Number(id));
+          } else if (action === 'UNLIKE') {
+            await deleteLikeConcert(Number(id));
+          }
+          break;
 
         default:
           throw new Error(`Unknown type: ${type}`);


### PR DESCRIPTION
## 📌 Summary

> - #147 

콘서트 좋아요 추가/삭제 API를 연동합니다.

## 📚 Tasks

- 콘서트 좋아요 추가/삭제 API 연동

## 👀 To Reviewer

- 아직 api 에러(?) 수정 안 돼서 연결되는지 확인은 못했지만 일단 푸시했습니다..~
- 확인했습니다~~~

<!--
## 📸 Screenshot
--!>