### PR TITLE
Fix(design-system): progress-bar 및 ticketing-carousel 글자 간격 조정

### DIFF
--- a/packages/design-system/src/components/ticketing-carousel/progress-bar/progress-bar.css.ts
+++ b/packages/design-system/src/components/ticketing-carousel/progress-bar/progress-bar.css.ts
@@ -9,6 +9,7 @@ export const progressBarVariants = recipe({
     flexDirection: 'column',
     gap: '0.8rem',
     padding: '0.4rem 0.8rem',
+    letterSpacing: '0.1rem',
     borderRadius: '3.2rem',
   },
   variants: {

--- a/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
+++ b/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
@@ -54,6 +54,8 @@ export const textSection = style({
 });
 
 export const description = style({
+  ...themeVars.display.flexColumn,
+  gap: '0.8rem',
   position: 'absolute',
   top: '1.6rem',
 });


### PR DESCRIPTION
## 📌 Summary

* #117 

## 📚 Tasks

* 자간의 악마 `신수진`이 명령한 자간간격 조정했습니다.


## 👀 To Reviewer

to 디자이너에게


## 📸 Screenshot

### before

![image](https://github.com/user-attachments/assets/e1dff478-455c-4274-a653-c1bed4373649)

![image](https://github.com/user-attachments/assets/2842e79d-fb37-4a84-a2b4-72b8df9edfc9)

### after

![image](https://github.com/user-attachments/assets/284802ce-c741-428e-959e-5e9720c24508)
![image](https://github.com/user-attachments/assets/fa15d21b-dd98-44db-af8f-b795156b3834)
