### PR TITLE
Fix(design-system): (QA/2) 하단배너 클릭시 상세보기 페이지 이동기능 수정

### DIFF
--- a/packages/design-system/src/components/ticketing-carousel/info-button/info-button.tsx
+++ b/packages/design-system/src/components/ticketing-carousel/info-button/info-button.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import { cn } from '../../../utils';
 import { infoButtonVariants } from './info-button.css';
 import SvgIcArrowWhite12 from '../../../icons/src/IcArrowWhite12';
@@ -12,22 +11,9 @@ interface InfoButtonProps
   performanceType?: string;
 }
 
-const InfoButton = ({
-  className,
-  title,
-  size = 'md',
-  typeId,
-  performanceType,
-}: InfoButtonProps) => {
-  const navigate = useNavigate();
-  const handleClick = () => {
-    navigate(`/${performanceType}-detail/${typeId}`);
-  };
+const InfoButton = ({ className, title, size = 'md' }: InfoButtonProps) => {
   return (
-    <button
-      className={cn(infoButtonVariants({ size: size }), className)}
-      onClick={handleClick}
-    >
+    <button className={cn(infoButtonVariants({ size: size }), className)}>
       {title}
       <SvgIcArrowWhite12 width={'1.2rem'} height={'1.2rem'} />
     </button>

--- a/packages/design-system/src/components/ticketing-carousel/progress-bar/progress-bar.tsx
+++ b/packages/design-system/src/components/ticketing-carousel/progress-bar/progress-bar.tsx
@@ -7,10 +7,19 @@ interface Props {
   total: number;
 }
 
-const ProgressBar = ({ current, total }: Props) => (
-  <div className={cn(progressBarVariants({ size: 'md' }))}>
-    {current}/{total}
-  </div>
-);
+const ProgressBar = ({ current, total }: Props) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div
+      className={cn(progressBarVariants({ size: 'md' }))}
+      onClick={handleClick}
+    >
+      {current}/{total}
+    </div>
+  );
+};
 
 export default ProgressBar;

--- a/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.tsx
+++ b/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.tsx
@@ -22,7 +22,7 @@ interface CarouselWrapProps {
 interface CarouselContainerProps {
   children: React.ReactNode;
   currentImageId: number;
-  type: string;
+  performanceType: string;
 }
 
 interface CarouselInfoProps {
@@ -89,7 +89,7 @@ const CarouselWrap = ({ performances, indexData }: CarouselWrapProps) => {
       </div>
       <TicketingCarousel.Container
         currentImageId={performanceData.typeId[currentIndex] ?? -1}
-        type={performanceData.type[currentIndex] || ''}
+        performanceType={performanceData.type[currentIndex] || ''}
       >
         <TicketingCarousel.Info>
           <div className={styles.description}>
@@ -124,12 +124,12 @@ const CarouselWrap = ({ performances, indexData }: CarouselWrapProps) => {
 const CarouselContainer = ({
   children,
   currentImageId,
-  type,
+  performanceType,
 }: CarouselContainerProps) => {
   const navigate = useNavigate();
 
   const handleContainerClick = () => {
-    navigate(`/${type}-detail/${currentImageId}`);
+    navigate(`/${performanceType}-detail/${currentImageId}`);
   };
 
   return (

--- a/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.tsx
+++ b/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.tsx
@@ -6,6 +6,7 @@ import { useCarouselData } from './hooks/use-carousel-data';
 import { useCarouselSlide } from './hooks/use-carousel-slide';
 import { useControlTime } from './hooks/use-control-time';
 import { useDateFormat } from './hooks/use-data-format';
+import { useNavigate } from 'react-router-dom';
 interface CarouselWrapProps {
   performances: {
     index: number;
@@ -20,6 +21,8 @@ interface CarouselWrapProps {
 
 interface CarouselContainerProps {
   children: React.ReactNode;
+  currentImageId: number;
+  type: string;
 }
 
 interface CarouselInfoProps {
@@ -84,7 +87,10 @@ const CarouselWrap = ({ performances, indexData }: CarouselWrapProps) => {
           />
         ))}
       </div>
-      <TicketingCarousel.Container>
+      <TicketingCarousel.Container
+        currentImageId={performanceData.typeId[currentIndex] ?? -1}
+        type={performanceData.type[currentIndex] || ''}
+      >
         <TicketingCarousel.Info>
           <div className={styles.description}>
             <TicketingCarousel.Dday reserveAt={dDay} />
@@ -115,9 +121,23 @@ const CarouselWrap = ({ performances, indexData }: CarouselWrapProps) => {
   );
 };
 
-const CarouselContainer = ({ children }: CarouselContainerProps) => (
-  <div className={styles.container}>{children}</div>
-);
+const CarouselContainer = ({
+  children,
+  currentImageId,
+  type,
+}: CarouselContainerProps) => {
+  const navigate = useNavigate();
+
+  const handleContainerClick = () => {
+    navigate(`/${type}-detail/${currentImageId}`);
+  };
+
+  return (
+    <div className={styles.container} onClick={handleContainerClick}>
+      {children}
+    </div>
+  );
+};
 
 const CarouselInfo = ({ children }: CarouselInfoProps) => (
   <section className={styles.info}>


### PR DESCRIPTION
## 📌 Summary

> - #211 

하단배너 클릭시 상세보기 페이지 이동기능 수정
'공연 정보 확인하기' 버튼이 아닌 이미지 전체 영역클리시 이동하기로 수정합니다.

## 📚 Tasks

- 하단배너 클릭시 상세보기 페이지 이동기능 수정

## 👀 To Reviewer

- 하단배너 클릭하면 상세 페이지로 이동합니다
- 위 기능을 캐러셀 컨테이너에 추가해서 공연 정보 확인하기 버튼 클릭하면 두 번 클릭되길래 버튼에 있는 onClick은 삭제하였습니다.
- progress bar는 클릭 불가능하게 설정했습니다
- 버튼에는 커서 포인터 설정되어 있으나 캐러셀 컨테이너에도 추가해야할지.. 는 디자이너분들과 상의해보겠습니다.....

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
