### PR TITLE
Fix(design-system): 디데이 계산 로직 수정

### DIFF
--- a/packages/design-system/src/components/ticketing-carousel/hooks/use-data-format.ts
+++ b/packages/design-system/src/components/ticketing-carousel/hooks/use-data-format.ts
@@ -9,6 +9,11 @@ export const useDateFormat = (reserveAt: string) => {
   const calculateDday = () => {
     const currentDate = new Date();
     const targetDate = new Date(reserveAt.split('.').join('-')); // 같은 형식으로 변환
+
+    // 시간 초기화 (00:00:00)
+    currentDate.setHours(0, 0, 0, 0);
+    targetDate.setHours(0, 0, 0, 0);
+
     const timeDifference = targetDate.getTime() - currentDate.getTime();
     const remainingDays = Math.ceil(timeDifference / (1000 * 3600 * 24)); // 남은 일수 계산
 


### PR DESCRIPTION
## 📌 Summary

> - #243 

메인 페이지 하단 배너의 디데이 계산 오류를 수정했니다.

## 📚 Tasks

- 메인 페이지 하단 배너 디데이 계산 오류 수정

## 👀 To Reviewer

currentDate와 targetDate 간의 시간 차이를 계산할 때 시간 단위는 버리고 날짜만 비교하도록 currentDate와 targetDate의 시간을 초기화했습니다~

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/0fb013be-07b6-4132-ba90-2235f25b477a)