### PR TITLE
Fix(client): (QA/4) 비로그인 상태로 홈화면 이동시 에러 수정

### DIFF
--- a/apps/client/src/pages/home/page/home.tsx
+++ b/apps/client/src/pages/home/page/home.tsx
@@ -18,14 +18,12 @@ const Home = () => {
   const { performanceCount, performances } = useTicketing();
   const { latestPerformances } = useLatestPerformances();
   const userId = localStorage.getItem(USER_ID_KEY);
-  const { data: profileData, isLoading } = useUserProfile();
-  const isHighlighted = Number(userId) === USER_DATA.data.userId;
+  const { data: profileData } = useUserProfile();
+  const isHighlighted = profileData && Number(userId) === USER_DATA.data.userId;
   const navigate = useNavigate();
 
   const handleGoHome = () => navigate(routePath.ROOT);
   const handleGoToTimeTable = () => navigate(routePath.TIME_TABLE_OUTLET);
-
-  if (isLoading) return null;
 
   return (
     <>
@@ -45,7 +43,7 @@ const Home = () => {
           </section>
           <section className={styles.ticketingBannerContainer}>
             <p className={styles.ticketingBannerText}>
-              {isHighlighted && profileData ? (
+              {isHighlighted ? (
                 <>
                   <span className={styles.highlightedText}>
                     {profileData.username}

--- a/apps/client/src/pages/home/page/home.tsx
+++ b/apps/client/src/pages/home/page/home.tsx
@@ -18,11 +18,14 @@ const Home = () => {
   const { performanceCount, performances } = useTicketing();
   const { latestPerformances } = useLatestPerformances();
   const userId = localStorage.getItem(USER_ID_KEY);
-  const profileData = useUserProfile();
+  const { data: profileData, isLoading } = useUserProfile();
   const isHighlighted = Number(userId) === USER_DATA.data.userId;
   const navigate = useNavigate();
+
   const handleGoHome = () => navigate(routePath.ROOT);
   const handleGoToTimeTable = () => navigate(routePath.TIME_TABLE_OUTLET);
+
+  if (isLoading) return null;
 
   return (
     <>
@@ -38,13 +41,11 @@ const Home = () => {
 
         <div className={styles.background}>
           <section className={styles.performanceBannerContainer}>
-            <PerformanceCarousel
-              performData={latestPerformances}
-            ></PerformanceCarousel>
+            <PerformanceCarousel performData={latestPerformances} />
           </section>
           <section className={styles.ticketingBannerContainer}>
             <p className={styles.ticketingBannerText}>
-              {isHighlighted ? (
+              {isHighlighted && profileData ? (
                 <>
                   <span className={styles.highlightedText}>
                     {profileData.username}
@@ -65,7 +66,6 @@ const Home = () => {
           </section>
         </div>
       </Navigation.Root>
-
       <Footer />
     </>
   );

--- a/apps/client/src/pages/my/hooks/use-my-favorites.ts
+++ b/apps/client/src/pages/my/hooks/use-my-favorites.ts
@@ -1,21 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { USER_QUERY_OPTIONS } from '@shared/apis/user/user-queries';
-import { USER_ID_KEY } from '@shared/constants/user-constants';
+import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 
 export const useMyArtist = () => {
-  const userId = localStorage.getItem(USER_ID_KEY);
+  const isNotLoggedIn = checkIsNotLoggedIn();
   const { data } = useQuery({
     ...USER_QUERY_OPTIONS.FAVORITE_ARTISTS(),
-    enabled: !!userId,
+    enabled: !isNotLoggedIn,
   });
   return { data, isLoading: !data };
 };
 
 export const useMyConfeti = () => {
-  const userId = localStorage.getItem(USER_ID_KEY);
+  const isNotLoggedIn = checkIsNotLoggedIn();
   const { data } = useQuery({
     ...USER_QUERY_OPTIONS.FAVORITE_PERFORMANCES(),
-    enabled: !!userId,
+    enabled: !isNotLoggedIn,
   });
   return { data, isLoading: !data };
 };

--- a/apps/client/src/pages/my/hooks/use-my-favorites.ts
+++ b/apps/client/src/pages/my/hooks/use-my-favorites.ts
@@ -1,12 +1,21 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { USER_QUERY_OPTIONS } from '@shared/apis/user/user-queries';
+import { USER_ID_KEY } from '@shared/constants/user-constants';
 
 export const useMyArtist = () => {
-  const { data } = useSuspenseQuery(USER_QUERY_OPTIONS.FAVORITE_ARTISTS());
-  return { data };
+  const userId = localStorage.getItem(USER_ID_KEY);
+  const { data } = useQuery({
+    ...USER_QUERY_OPTIONS.FAVORITE_ARTISTS(),
+    enabled: !!userId,
+  });
+  return { data, isLoading: !data };
 };
 
 export const useMyConfeti = () => {
-  const { data } = useSuspenseQuery(USER_QUERY_OPTIONS.FAVORITE_PERFORMANCES());
-  return { data };
+  const userId = localStorage.getItem(USER_ID_KEY);
+  const { data } = useQuery({
+    ...USER_QUERY_OPTIONS.FAVORITE_PERFORMANCES(),
+    enabled: !!userId,
+  });
+  return { data, isLoading: !data };
 };

--- a/apps/client/src/pages/my/hooks/use-my-favorites.ts
+++ b/apps/client/src/pages/my/hooks/use-my-favorites.ts
@@ -8,7 +8,8 @@ export const useMyArtist = () => {
     ...USER_QUERY_OPTIONS.FAVORITE_ARTISTS(),
     enabled: !isNotLoggedIn,
   });
-  return { data, isLoading: !data };
+  // 로딩 상태 제거
+  return { data };
 };
 
 export const useMyConfeti = () => {
@@ -17,5 +18,6 @@ export const useMyConfeti = () => {
     ...USER_QUERY_OPTIONS.FAVORITE_PERFORMANCES(),
     enabled: !isNotLoggedIn,
   });
-  return { data, isLoading: !data };
+  // 로딩 상태 제거
+  return { data };
 };

--- a/apps/client/src/pages/my/hooks/use-user-info.ts
+++ b/apps/client/src/pages/my/hooks/use-user-info.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { USER_QUERY_OPTIONS } from '@shared/apis/user/user-queries';
-import { USER_ID_KEY } from '@shared/constants/user-constants';
+import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 
 export const useUserProfile = () => {
-  const userId = localStorage.getItem(USER_ID_KEY);
+  const isNotLoggedIn = checkIsNotLoggedIn();
   const { data, isLoading } = useQuery({
     ...USER_QUERY_OPTIONS.PROFILE(),
-    enabled: !!userId,
+    enabled: !isNotLoggedIn,
   });
   return { data, isLoading };
 };

--- a/apps/client/src/pages/my/hooks/use-user-info.ts
+++ b/apps/client/src/pages/my/hooks/use-user-info.ts
@@ -1,8 +1,12 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
-
+import { useQuery } from '@tanstack/react-query';
 import { USER_QUERY_OPTIONS } from '@shared/apis/user/user-queries';
+import { USER_ID_KEY } from '@shared/constants/user-constants';
 
 export const useUserProfile = () => {
-  const { data } = useSuspenseQuery(USER_QUERY_OPTIONS.PROFILE());
-  return data;
+  const userId = localStorage.getItem(USER_ID_KEY);
+  const { data, isLoading } = useQuery({
+    ...USER_QUERY_OPTIONS.PROFILE(),
+    enabled: !!userId,
+  });
+  return { data, isLoading };
 };

--- a/apps/client/src/pages/my/hooks/use-user-info.ts
+++ b/apps/client/src/pages/my/hooks/use-user-info.ts
@@ -4,9 +4,9 @@ import { checkIsNotLoggedIn } from '@shared/utils/check-is-not-logged-in';
 
 export const useUserProfile = () => {
   const isNotLoggedIn = checkIsNotLoggedIn();
-  const { data, isLoading } = useQuery({
+  const { data } = useQuery({
     ...USER_QUERY_OPTIONS.PROFILE(),
     enabled: !isNotLoggedIn,
   });
-  return { data, isLoading };
+  return { data };
 };

--- a/apps/client/src/pages/my/page/artist/artist-more.tsx
+++ b/apps/client/src/pages/my/page/artist/artist-more.tsx
@@ -4,9 +4,9 @@ import * as styles from './artist-more.css';
 import { ARTISTS_DATA } from '@shared/mocks/artists-data';
 
 const ArtistMore = () => {
-  const { data, isLoading } = useMyArtist();
+  const { data } = useMyArtist();
 
-  if (isLoading || !data) return null;
+  if (!data) return null;
 
   const allArtists = [...data.artists, ...ARTISTS_DATA.artists];
 

--- a/apps/client/src/pages/my/page/artist/artist-more.tsx
+++ b/apps/client/src/pages/my/page/artist/artist-more.tsx
@@ -4,7 +4,10 @@ import * as styles from './artist-more.css';
 import { ARTISTS_DATA } from '@shared/mocks/artists-data';
 
 const ArtistMore = () => {
-  const { data } = useMyArtist();
+  const { data, isLoading } = useMyArtist();
+
+  if (isLoading || !data) return null;
+
   const allArtists = [...data.artists, ...ARTISTS_DATA.artists];
 
   return (
@@ -24,5 +27,4 @@ const ArtistMore = () => {
     </>
   );
 };
-
 export default ArtistMore;

--- a/apps/client/src/pages/my/page/confeti/confeti-more.tsx
+++ b/apps/client/src/pages/my/page/confeti/confeti-more.tsx
@@ -4,7 +4,10 @@ import { useMyConfeti } from '@pages/my/hooks/use-my-favorites';
 import * as styles from './confeti-more.css';
 
 const ConfetiMore = () => {
-  const { data } = useMyConfeti();
+  const { data, isLoading } = useMyConfeti();
+
+  if (isLoading || !data) return null;
+
   const allPerformances = [
     ...data.performances,
     ...PERFORMANCE_DATA.performances,

--- a/apps/client/src/pages/my/page/confeti/confeti-more.tsx
+++ b/apps/client/src/pages/my/page/confeti/confeti-more.tsx
@@ -4,9 +4,9 @@ import { useMyConfeti } from '@pages/my/hooks/use-my-favorites';
 import * as styles from './confeti-more.css';
 
 const ConfetiMore = () => {
-  const { data, isLoading } = useMyConfeti();
+  const { data } = useMyConfeti();
 
-  if (isLoading || !data) return null;
+  if (!data) return null;
 
   const allPerformances = [
     ...data.performances,

--- a/apps/client/src/pages/my/page/profile/my-profile.tsx
+++ b/apps/client/src/pages/my/page/profile/my-profile.tsx
@@ -11,19 +11,11 @@ import ConfetiSection from '@pages/my/components/confeti/confeti-section';
 import { useMyArtist, useMyConfeti } from '@pages/my/hooks/use-my-favorites';
 
 const MyProfile = () => {
-  const { data: profileData, isLoading: profileLoading } = useUserProfile();
-  const { data: artistData, isLoading: artistLoading } = useMyArtist();
-  const { data: performanceData, isLoading: performanceLoading } =
-    useMyConfeti();
+  const { data: profileData } = useUserProfile();
+  const { data: artistData } = useMyArtist();
+  const { data: performanceData } = useMyConfeti();
 
-  if (
-    profileLoading ||
-    artistLoading ||
-    performanceLoading ||
-    !profileData ||
-    !artistData ||
-    !performanceData
-  ) {
+  if (!profileData || !artistData || !performanceData) {
     return null;
   }
 

--- a/apps/client/src/pages/my/page/profile/my-profile.tsx
+++ b/apps/client/src/pages/my/page/profile/my-profile.tsx
@@ -11,9 +11,21 @@ import ConfetiSection from '@pages/my/components/confeti/confeti-section';
 import { useMyArtist, useMyConfeti } from '@pages/my/hooks/use-my-favorites';
 
 const MyProfile = () => {
-  const profileData = useUserProfile();
-  const { data: artistData } = useMyArtist();
-  const { data: performanceData } = useMyConfeti();
+  const { data: profileData, isLoading: profileLoading } = useUserProfile();
+  const { data: artistData, isLoading: artistLoading } = useMyArtist();
+  const { data: performanceData, isLoading: performanceLoading } =
+    useMyConfeti();
+
+  if (
+    profileLoading ||
+    artistLoading ||
+    performanceLoading ||
+    !profileData ||
+    !artistData ||
+    !performanceData
+  ) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## 📌 Summary

- #210 

## 📚 Tasks

- 비회원일 때 api 요청 막아두는 기능 구현

## 👀 To Reviewer
`suspensequery`에선 `enabled`를 사용하지 못해서 `useQuery`로 변경했습니다

## 📸 Screenshot

https://github.com/user-attachments/assets/5e219ace-cb58-40bd-9f61-f28b70567ac7



