### PR TITLE
Feat(client): 애니메이션 추가를 통한 UX개선

### DIFF
--- a/apps/client/src/pages/confeti/components/expanded/expanded-section.css.ts
+++ b/apps/client/src/pages/confeti/components/expanded/expanded-section.css.ts
@@ -3,9 +3,18 @@ import { themeVars } from '@confeti/design-system/styles';
 
 export const expandedSection = style({
   ...themeVars.display.flexColumn,
+  position: 'relative',
 });
 
 export const expandedArtists = style({
-  backgroundColor: themeVars.color.gray100,
+  backgroundColor: themeVars.color.gray200,
+  overflow: 'hidden',
+  transition: 'height 0.4s ease-out, opacity 0s ease-out',
+  opacity: 0,
+  padding: '0 2rem',
+});
+
+export const expandedArtistsVisible = style({
+  opacity: 1,
   padding: '2rem',
 });

--- a/apps/client/src/pages/confeti/components/expanded/expanded-section.tsx
+++ b/apps/client/src/pages/confeti/components/expanded/expanded-section.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from 'react';
 import { ConcertArtist } from '../../types/concert';
 import MoreButton from '@pages/confeti/components/button/more-button';
 import ArtistGrid from '@pages/confeti/components/artist/artist-grid';
@@ -14,25 +15,39 @@ interface ExpandedSectionProps {
 }
 
 const ExpandedSection = ({
-  isOpen,
   isExpanded,
   artists,
   dayId,
   toggleExpand,
 }: ExpandedSectionProps) => {
-  if (!isOpen) return null;
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const timer = requestAnimationFrame(() => {
+      if (contentRef.current) {
+        setHeight(isExpanded ? contentRef.current.scrollHeight : 0);
+      }
+    });
+
+    return () => cancelAnimationFrame(timer);
+  }, [isExpanded]);
 
   return (
     <section className={styles.expandedSection}>
-      {isExpanded && (
-        <div className={styles.expandedArtists}>
-          <ArtistGrid
-            artists={artists.slice(MAX_VISIBLE_ARTISTS)}
-            dayId={dayId}
-            type="expanded"
-          />
-        </div>
-      )}
+      <div
+        ref={contentRef}
+        className={`${styles.expandedArtists} ${isExpanded ? styles.expandedArtistsVisible : ''}`}
+        style={{
+          height: isExpanded ? `${height}px` : '0',
+        }}
+      >
+        <ArtistGrid
+          artists={artists.slice(MAX_VISIBLE_ARTISTS)}
+          dayId={dayId}
+          type="expanded"
+        />
+      </div>
       <MoreButton
         isExpanded={isExpanded}
         onToggle={() => toggleExpand(dayId)}

--- a/apps/client/src/pages/confeti/components/performance/performance-detail.css.ts
+++ b/apps/client/src/pages/confeti/components/performance/performance-detail.css.ts
@@ -6,17 +6,19 @@ export const container = style({
   backgroundColor: themeVars.color.white,
   maxHeight: '50.8rem',
   overflow: 'hidden',
-  transition: 'max-height 0.3s ease',
+  transition: 'max-height 1.3s ease-in-out',
+  opacity: 1,
 });
 
 export const expanded = style({
-  maxHeight: 'none',
+  maxHeight: '500rem',
   overflow: 'visible',
 });
 
 export const collapsed = style({
-  maxHeight: '50rem',
+  maxHeight: '50.8rem',
   overflow: 'hidden',
+  transition: 'none',
 });
 
 export const wrapper = style({

--- a/apps/client/src/pages/time-table/components/info/info-button.css.ts
+++ b/apps/client/src/pages/time-table/components/info/info-button.css.ts
@@ -1,5 +1,14 @@
 import { recipe } from '@vanilla-extract/recipes';
 import { themeVars } from '@confeti/design-system/styles';
+import { keyframes } from '@vanilla-extract/css';
+
+const shake = keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '25%': { transform: 'rotate(-5deg)' },
+  '50%': { transform: 'rotate(5deg)' },
+  '75%': { transform: 'rotate(-5deg)' },
+  '100%': { transform: 'rotate(0deg)' },
+});
 
 export const containerVariants = recipe({
   base: {
@@ -82,6 +91,11 @@ export const ImageVariants = recipe({
         backgroundOrigin: 'border-box',
         backgroundClip: 'content-box, border-box',
         transition: 'background-image 0.4s ease, border-color 0.4s ease',
+      },
+    },
+    isFestivalDeleteMode: {
+      true: {
+        animation: `${shake} 0.5s ease-in-out infinite`,
       },
     },
   },

--- a/apps/client/src/pages/time-table/components/info/info-button.tsx
+++ b/apps/client/src/pages/time-table/components/info/info-button.tsx
@@ -39,6 +39,7 @@ interface InfoItemsProps {
   text: string;
   size?: SizeType;
   isClicked?: boolean;
+  isFestivalDeleteMode?: boolean;
   onClick: () => void;
 }
 
@@ -81,13 +82,22 @@ const FixedButton = ({ size = 'md' }: FixedButtonProps) => {
     </>
   );
 };
-const InfoItems = ({ src, alt, text, isClicked, onClick }: InfoItemsProps) => (
+
+const InfoItems = ({
+  src,
+  alt,
+  text,
+  isClicked,
+  onClick,
+  isFestivalDeleteMode,
+}: InfoItemsProps) => (
   <>
     <InfoButton.ImageField
       src={src}
       alt={alt}
       isClicked={isClicked}
       onClick={onClick}
+      isFestivalDeleteMode={isFestivalDeleteMode}
     />
     <InfoButton.TextField text={text} color="black" />
   </>
@@ -99,13 +109,17 @@ const ItemImage = ({
   alt,
   isClicked,
   onClick,
-}: ItemImagesProps) => (
-  <img
-    className={cn(ImageVariants({ size, isClicked }))}
-    src={src}
-    alt={alt}
-    onClick={onClick}
-  />
+  isFestivalDeleteMode,
+}: ItemImagesProps & { isFestivalDeleteMode?: boolean }) => (
+  console.log(isFestivalDeleteMode),
+  (
+    <img
+      className={cn(ImageVariants({ size, isClicked, isFestivalDeleteMode }))}
+      src={src}
+      alt={alt}
+      onClick={onClick}
+    />
+  )
 );
 
 const ItemText = ({ size = 'md', text, color }: ItemTextProps) => (

--- a/apps/client/src/pages/time-table/page/time-table.tsx
+++ b/apps/client/src/pages/time-table/page/time-table.tsx
@@ -61,7 +61,7 @@ const TimeTable = () => {
   return (
     <>
       {festivals.length === 0 ? (
-        <EmptyFestivalSection></EmptyFestivalSection>
+        <EmptyFestivalSection />
       ) : (
         <>
           <InfoButton.TotalWrap festivals={festivals}>
@@ -79,6 +79,7 @@ const TimeTable = () => {
                       text={title}
                       onClick={() => handleFestivalClick(festivalId)}
                       isClicked={clickedFestivalId === festivalId}
+                      isFestivalDeleteMode={isFestivalDeleteMode}
                     />
                     {festivalId && (
                       <DeleteButton


### PR DESCRIPTION
## 📌 Summary

> - #278 

## 📚 Tasks

- 페스티벌 삭제모드시 애니메이션 추가
- 상세정보 펼치기 애니메이션 추가
- 아티스트 목록 펼치기 애니메이션 추가


https://github.com/user-attachments/assets/7b084c31-5098-4ea3-9a8c-a89309b0216b

https://github.com/user-attachments/assets/b744c4d3-01f6-4c43-9436-df2924cdddab


