### PR TITLE
Fix(client): 공연 정보 조회 무한 스크롤 해결 및 공연 개수 api 연결

### DIFF
--- a/apps/client/src/pages/search/page/search.tsx
+++ b/apps/client/src/pages/search/page/search.tsx
@@ -6,6 +6,7 @@ import PerformanceSection from '@pages/search/components/performance-section';
 import PerformanceCount from '@pages/search/components/performance-count-section';
 import { useSearchLogic } from '../hooks/use-search-logic';
 import { useSearchPerformances } from '../hooks/use-search-data';
+import { useInfiniteScroll } from '@shared/utils/use-infinite-scroll';
 
 const Search = () => {
   const {
@@ -19,14 +20,13 @@ const Search = () => {
   } = useSearchLogic();
 
   const artistId = artistData[0]?.artistId || '';
-  const performancesData = useSearchPerformances({
-    artistId,
-    cursor: 1,
-    enabled: !!artistId,
-  });
+  const { performances, performanceCount, fetchNextPage, hasNextPage } =
+    useSearchPerformances({
+      artistId,
+      enabled: !!artistId,
+    });
 
-  const performances = performancesData?.performances || [];
-  const performanceCount = performances.length;
+  const observerRef = useInfiniteScroll(hasNextPage, fetchNextPage);
 
   return (
     <>
@@ -46,6 +46,9 @@ const Search = () => {
             <Spacing />
             <PerformanceCount count={performanceCount} />
             <PerformanceSection performances={performances} />
+            {hasNextPage && (
+              <div ref={observerRef} style={{ height: '2rem' }} />
+            )}
           </main>
           <Footer />
         </>

--- a/apps/client/src/pages/time-table/page/add-festival.tsx
+++ b/apps/client/src/pages/time-table/page/add-festival.tsx
@@ -53,7 +53,7 @@ const AddFestival = () => {
             />
           );
         })}
-        {hasNextPage && <div ref={observerRef} style={{ height: '20px' }} />}
+        {hasNextPage && <div ref={observerRef} style={{ height: '2rem' }} />}
       </div>
       <div className={styles.buttonSection}>
         <Button

--- a/apps/client/src/shared/apis/search/search-queries.ts
+++ b/apps/client/src/shared/apis/search/search-queries.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getArtistSearch, getPerformancesSearch } from './search';
+import { GetPerformancesSearchResponse } from '@shared/types/search-reponse';
 
 export const SEARCH_ARTIST_QUERY_KEY = {
   ALL: ['artist'],
@@ -30,17 +31,14 @@ export const SEARCH_PERFORMANCES_QUERY_KEY = {
 } as const;
 
 export const SEARCH_PERFORMANCES_QUERY_OPTION = {
-  ALL: () => queryOptions({ queryKey: SEARCH_PERFORMANCES_QUERY_KEY.ALL }),
-  SEARCH_PERFORMANCES: (
-    artistId: string,
-    cursor: number,
-    enabled: boolean,
-  ) => ({
-    queryKey: SEARCH_PERFORMANCES_QUERY_KEY.SEARCH_PERFORMANCES(
-      artistId,
-      cursor,
-    ),
-    queryFn: () => getPerformancesSearch(artistId, cursor),
+  SEARCH_PERFORMANCES: (artistId: string, enabled: boolean) => ({
+    queryKey: ['performances', artistId],
+    queryFn: ({ pageParam = 1 }: { pageParam?: number }) =>
+      getPerformancesSearch(artistId, pageParam),
     enabled,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage: GetPerformancesSearchResponse) => {
+      return lastPage.nextCursor !== -1 ? lastPage.nextCursor : undefined;
+    },
   }),
 };

--- a/apps/client/src/shared/apis/search/search.ts
+++ b/apps/client/src/shared/apis/search/search.ts
@@ -19,10 +19,8 @@ export const getPerformancesSearch = async (
   artistId: string,
   cursor: number,
 ): Promise<GetPerformancesSearchResponse> => {
-  const url =
-    cursor === 1
-      ? `performances/association/${artistId}`
-      : `performances/association/${artistId}?cursor=${cursor}`;
+  const baseUrl = `performances/association/${artistId}`;
+  const url = cursor === 1 ? baseUrl : `${baseUrl}?cursor=${cursor}`;
 
   const response = await get<BaseResponse<GetPerformancesSearchResponse>>(url);
   return response.data;

--- a/apps/client/src/shared/types/search-reponse.ts
+++ b/apps/client/src/shared/types/search-reponse.ts
@@ -23,5 +23,6 @@ export interface Performance {
 
 export interface GetPerformancesSearchResponse {
   nextCursor: number;
+  performanceCount: number;
   performances: Performance[];
 }


### PR DESCRIPTION
## 📌 Summary
- #275 

## 📚 Tasks

- 공연 정보 조회 무한 스크롤 구현 및 공연 개수도 서버 응답값 사용하게 수정하였습니다.

<!--
## 👀 To Reviewer

(기재 내용 없을 경우 섹션 삭제) 더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
