### PR TITLE
Fix: (QA/4) 페스티벌 삭제 시 이슈 해결

### DIFF
--- a/apps/client/src/pages/confeti/components/expanded/expanded-section.css.ts
+++ b/apps/client/src/pages/confeti/components/expanded/expanded-section.css.ts
@@ -9,7 +9,7 @@ export const expandedSection = style({
 export const expandedArtists = style({
   backgroundColor: themeVars.color.gray200,
   overflow: 'hidden',
-  transition: 'height 0.4s ease-out, opacity 0s ease-out',
+  transition: 'height 0.5s ease-out, opacity 0s ease-out',
   opacity: 0,
   padding: '0 2rem',
 });

--- a/apps/client/src/pages/time-table/components/add/add-button.tsx
+++ b/apps/client/src/pages/time-table/components/add/add-button.tsx
@@ -2,14 +2,25 @@ import { cn } from '@confeti/design-system/utils';
 import { addButtonVariants } from './add-button.css';
 import SvgBtnAddGray24 from 'node_modules/@confeti/design-system/src/icons/src/BtnAddGray24';
 
-interface AddButtonProps {
+interface AddButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: 'sm' | 'md' | 'lg';
   onClick?: () => void;
+  disabled: boolean;
 }
 
-const AddButton = ({ onClick, size = 'md' }: AddButtonProps) => {
+const AddButton = ({
+  onClick,
+  size = 'md',
+  disabled,
+  ...props
+}: AddButtonProps) => {
   return (
-    <button className={cn(addButtonVariants({ size: size }))} onClick={onClick}>
+    <button
+      className={cn(addButtonVariants({ size: size }))}
+      disabled={disabled}
+      {...props}
+      onClick={onClick}
+    >
       <SvgBtnAddGray24 width={'2rem'} height={'2rem'} />
     </button>
   );

--- a/apps/client/src/pages/time-table/components/edit/edit-floating-button.tsx
+++ b/apps/client/src/pages/time-table/components/edit/edit-floating-button.tsx
@@ -10,7 +10,8 @@ import { useDeleteTimeTableFestival } from '@pages/time-table/hooks/use-timetabl
 import { useScrollPosition } from '@pages/time-table/hooks/use-scroll-position';
 import { EDIT_BOX, EDIT_BUTTON } from '../../constants/edit-floating-text';
 import * as styles from './edit-floating-button.css';
-
+import { queryClient } from '@shared/utils/query-client';
+import { FestivalTimetable } from '@shared/types/festival-timetable-response';
 interface EditFloatingButtonProps {
   isEditMode: boolean;
   isEditTimeTableMode: boolean;
@@ -23,6 +24,8 @@ interface EditFloatingButtonProps {
   onToggleComplete: () => void;
   onResetModes: () => void;
   festivalsToDelete: number[];
+  remainedFestival: FestivalTimetable[];
+  handleFestivalClick: (festivalId: number) => void;
 }
 
 const EditFloatingButton = ({
@@ -37,6 +40,8 @@ const EditFloatingButton = ({
   onToggleComplete,
   onResetModes,
   festivalsToDelete,
+  remainedFestival,
+  handleFestivalClick,
 }: EditFloatingButtonProps) => {
   const deleteFestival = useDeleteTimeTableFestival();
   const isAtBottom = useScrollPosition();
@@ -47,13 +52,18 @@ const EditFloatingButton = ({
   const handleToggleButton = () => {
     if (isEditTimeTableMode || isFestivalDeleteMode) {
       festivalsToDelete.map((id) => deleteFestival.mutate(id));
+      queryClient.invalidateQueries({
+        queryKey: ['festivalButton', 'festivalTimetable'],
+      });
+      if (remainedFestival.length > 0) {
+        handleFestivalClick(remainedFestival[0].festivalId);
+      }
       onResetModes();
     }
 
     onToggleEditMode();
     onToggleTextVisibility(true);
   };
-
   const getBackgroundClassName = () => {
     return ` ${
       isEditMode && !isEditTimeTableMode && !isFestivalDeleteMode

--- a/apps/client/src/pages/time-table/components/edit/edit-floating-button.tsx
+++ b/apps/client/src/pages/time-table/components/edit/edit-floating-button.tsx
@@ -9,9 +9,9 @@ import useDisableScroll from '@pages/time-table/hooks/use-disabled-scroll';
 import { useDeleteTimeTableFestival } from '@pages/time-table/hooks/use-timetable-festival-mutation';
 import { useScrollPosition } from '@pages/time-table/hooks/use-scroll-position';
 import { EDIT_BOX, EDIT_BUTTON } from '../../constants/edit-floating-text';
-import * as styles from './edit-floating-button.css';
-import { queryClient } from '@shared/utils/query-client';
 import { FestivalTimetable } from '@shared/types/festival-timetable-response';
+import * as styles from './edit-floating-button.css';
+
 interface EditFloatingButtonProps {
   isEditMode: boolean;
   isEditTimeTableMode: boolean;
@@ -52,9 +52,6 @@ const EditFloatingButton = ({
   const handleToggleButton = () => {
     if (isEditTimeTableMode || isFestivalDeleteMode) {
       festivalsToDelete.map((id) => deleteFestival.mutate(id));
-      queryClient.invalidateQueries({
-        queryKey: ['festivalButton', 'festivalTimetable'],
-      });
       if (remainedFestival.length > 0) {
         handleFestivalClick(remainedFestival[0].festivalId);
       }

--- a/apps/client/src/pages/time-table/components/info/info-button.tsx
+++ b/apps/client/src/pages/time-table/components/info/info-button.tsx
@@ -30,6 +30,7 @@ interface InfoItemContainerProps {
 
 interface FixedButtonProps {
   size?: SizeType;
+  disabled: boolean;
 }
 
 interface InfoItemsProps {
@@ -67,7 +68,7 @@ const InfoItemContainer = ({
   <div className={cn(ItemContainer({ size }))}>{children}</div>
 );
 
-const FixedButton = ({ size = 'md' }: FixedButtonProps) => {
+const FixedButton = ({ size = 'md', disabled }: FixedButtonProps) => {
   const navigate = useNavigate();
   return (
     <>
@@ -75,7 +76,7 @@ const FixedButton = ({ size = 'md' }: FixedButtonProps) => {
         className={cn(ItemsVariants({ size }))}
         onClick={() => navigate(routePath.ADDFESTIVAL)}
       >
-        <AddButton size="md" />
+        <AddButton size="md" disabled={disabled} />
         <InfoButton.TextField text={`페스티벌\n추가`} color="gray" />
       </div>
     </>

--- a/apps/client/src/pages/time-table/hooks/use-button-selection.ts
+++ b/apps/client/src/pages/time-table/hooks/use-button-selection.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 interface Festival {
   festivalId: number;

--- a/apps/client/src/pages/time-table/hooks/use-button-selection.ts
+++ b/apps/client/src/pages/time-table/hooks/use-button-selection.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 
 interface Festival {
   festivalId: number;

--- a/apps/client/src/pages/time-table/hooks/use-timetable-festival-mutation.ts
+++ b/apps/client/src/pages/time-table/hooks/use-timetable-festival-mutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteFestivalTimetables } from '@shared/apis/time-table/festival-timetable';
 import { addFestivalTimeTable } from '@shared/apis/time-table/festival-button';
 import { FESTIVAL_BUTTON_QUERY_KEY } from '@shared/apis/time-table/festival-button-queries';
+import { FESTIVAL_TIMETABLE_QUERY_KEY } from '@shared/apis/time-table/festival-timetable-queries';
 
 export const useDeleteTimeTableFestival = () => {
   const queryClient = useQueryClient();
@@ -10,7 +11,10 @@ export const useDeleteTimeTableFestival = () => {
     mutationFn: (festivalId: number) => deleteFestivalTimetables(festivalId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: FESTIVAL_BUTTON_QUERY_KEY.ALL,
+        queryKey: [
+          ...FESTIVAL_BUTTON_QUERY_KEY.ALL,
+          ...FESTIVAL_TIMETABLE_QUERY_KEY.ALL,
+        ],
       });
     },
   });

--- a/apps/client/src/pages/time-table/page/time-table.tsx
+++ b/apps/client/src/pages/time-table/page/time-table.tsx
@@ -44,18 +44,16 @@ const TimeTable = () => {
     setSelectedFestivalDateId,
   } = useButtonSelection(festivals);
 
-  useEffect(() => {
-    if (clickedFestivalId === null && festivals.length > 0) {
-      window.location.reload();
-    }
-  }, [clickedFestivalId, festivals.length]);
-
   const handleDateSelect = (festivalDateId: number) => {
     setSelectedFestivalDateId(festivalDateId);
   };
 
   const { data: boardData } = useFestivalTimetableData(
     selectedFestivalDateId as number,
+  );
+
+  const remainedFestival = festivals.filter(
+    ({ festivalId }) => !festivalsToDelete.includes(festivalId),
   );
 
   return (
@@ -67,28 +65,24 @@ const TimeTable = () => {
           <InfoButton.TotalWrap festivals={festivals}>
             <InfoButton.ItemContainer>
               <InfoButton.FixButton />
-              {festivals
-                .filter(
-                  ({ festivalId }) => !festivalsToDelete.includes(festivalId),
-                )
-                .map(({ festivalId, title, logoUrl }) => (
-                  <div className={styles.festivalBtnWrapper} key={festivalId}>
-                    <InfoButton.Items
-                      src={logoUrl}
-                      alt={title}
-                      text={title}
-                      onClick={() => handleFestivalClick(festivalId)}
-                      isClicked={clickedFestivalId === festivalId}
+              {remainedFestival.map(({ festivalId, title, logoUrl }) => (
+                <div className={styles.festivalBtnWrapper} key={festivalId}>
+                  <InfoButton.Items
+                    src={logoUrl}
+                    alt={title}
+                    text={title}
+                    onClick={() => handleFestivalClick(festivalId)}
+                    isClicked={clickedFestivalId === festivalId}
+                  />
+                  {festivalId && (
+                    <DeleteButton
+                      onDelete={() => handleDeleteFestival(festivalId)}
+                      isFestivalDeleteMode={isFestivalDeleteMode}
+                      festivalId={festivalId}
                     />
-                    {festivalId && (
-                      <DeleteButton
-                        onDelete={() => handleDeleteFestival(festivalId)}
-                        isFestivalDeleteMode={isFestivalDeleteMode}
-                        festivalId={festivalId}
-                      />
-                    )}
-                  </div>
-                ))}
+                  )}
+                </div>
+              ))}
             </InfoButton.ItemContainer>
           </InfoButton.TotalWrap>
           <Spacing />
@@ -118,6 +112,8 @@ const TimeTable = () => {
             onToggleComplete={toggleComplete}
             onResetModes={resetModes}
             festivalsToDelete={festivalsToDelete}
+            remainedFestival={remainedFestival}
+            handleFestivalClick={handleFestivalClick}
           />
         </>
       )}

--- a/apps/client/src/pages/time-table/page/time-table.tsx
+++ b/apps/client/src/pages/time-table/page/time-table.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Spacing } from '@confeti/design-system';
 import TimeTableBoard from '@pages/time-table/components/time-table-board/time-table-board';
 import EditFloatingButton from '@pages/time-table/components/edit/edit-floating-button';

--- a/apps/client/src/pages/time-table/page/time-table.tsx
+++ b/apps/client/src/pages/time-table/page/time-table.tsx
@@ -64,7 +64,7 @@ const TimeTable = () => {
         <>
           <InfoButton.TotalWrap festivals={festivals}>
             <InfoButton.ItemContainer>
-              <InfoButton.FixButton />
+              <InfoButton.FixButton disabled={isFestivalDeleteMode} />
               {remainedFestival.map(({ festivalId, title, logoUrl }) => (
                 <div className={styles.festivalBtnWrapper} key={festivalId}>
                   <InfoButton.Items

--- a/apps/client/src/pages/time-table/page/time-table.tsx
+++ b/apps/client/src/pages/time-table/page/time-table.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Spacing } from '@confeti/design-system';
 import TimeTableBoard from '@pages/time-table/components/time-table-board/time-table-board';
 import EditFloatingButton from '@pages/time-table/components/edit/edit-floating-button';
@@ -13,7 +14,6 @@ import {
 } from '../hooks/use-festival-data';
 
 import * as styles from './time-table.css';
-import { useState, useEffect } from 'react';
 
 const TimeTable = () => {
   const {

--- a/apps/client/src/shared/types/festival-timetable-response.ts
+++ b/apps/client/src/shared/types/festival-timetable-response.ts
@@ -3,7 +3,7 @@ interface FestivalDate {
   festivalAt: string;
 }
 
-interface FestivalTimetable {
+export interface FestivalTimetable {
   festivalId: number;
   title: string;
   logoUrl: string;


### PR DESCRIPTION
## 📌 Summary

> - #253 


## 📚 Tasks

- 선택된 페스티벌 삭제 시 자동으로 남아있는 페스티벌 중 첫번째를 선택되게 수정
- 삭제모드일때 추가하기 버튼 disabled 되도록 추가

## 📸 Screenshot

https://github.com/user-attachments/assets/a0362d78-b5cd-49c3-b7e6-9b582d981a00



