### PR TITLE
Fix(client): 콘서트 더보기 버튼 기능 수정

### DIFF
--- a/apps/client/src/pages/confeti/components/artist/artist-section.tsx
+++ b/apps/client/src/pages/confeti/components/artist/artist-section.tsx
@@ -20,9 +20,10 @@ interface FestivalArtistData {
 interface ArtistListProps {
   type: 'concert' | 'festival';
   artistData: ConcertArtistData | FestivalArtistData;
+  isMoreButton: boolean;
 }
 
-const ArtistSection = ({ type, artistData }: ArtistListProps) => {
+const ArtistSection = ({ type, artistData, isMoreButton }: ArtistListProps) => {
   const [expandedDays, setExpandedDays] = useState<Record<number, boolean>>({});
 
   const toggleExpand = (dayId: number) => {
@@ -50,13 +51,15 @@ const ArtistSection = ({ type, artistData }: ArtistListProps) => {
             type="visible"
           />
         </div>
-        <ExpandedSection
-          isOpen={isOpen}
-          isExpanded={isExpanded}
-          artists={concertArtists}
-          dayId={CONCERT_DEFAULT_ID}
-          toggleExpand={toggleExpand}
-        />
+        {isMoreButton && (
+          <ExpandedSection
+            isOpen={isOpen}
+            isExpanded={isExpanded}
+            artists={concertArtists}
+            dayId={CONCERT_DEFAULT_ID}
+            toggleExpand={toggleExpand}
+          />
+        )}
       </section>
     );
   }

--- a/apps/client/src/pages/confeti/components/artist/artist-section.tsx
+++ b/apps/client/src/pages/confeti/components/artist/artist-section.tsx
@@ -20,7 +20,7 @@ interface FestivalArtistData {
 interface ArtistListProps {
   type: 'concert' | 'festival';
   artistData: ConcertArtistData | FestivalArtistData;
-  isMoreButton: boolean;
+  isMoreButton?: boolean;
 }
 
 const ArtistSection = ({ type, artistData, isMoreButton }: ArtistListProps) => {

--- a/apps/client/src/pages/confeti/components/performance/performance-detail.css.ts
+++ b/apps/client/src/pages/confeti/components/performance/performance-detail.css.ts
@@ -11,7 +11,7 @@ export const container = style({
 });
 
 export const expanded = style({
-  maxHeight: '500rem',
+  maxHeight: '700rem',
   overflow: 'visible',
 });
 

--- a/apps/client/src/pages/confeti/page/concert-detail.tsx
+++ b/apps/client/src/pages/confeti/page/concert-detail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Info from '@pages/confeti/components/info/info';
 import Poster from '@pages/confeti/components/poster/poster';
@@ -13,14 +13,22 @@ import { useConcertDetail } from '@pages/confeti/hooks/use-concert-detail';
 const ConcertDetailPage = () => {
   const { typeId } = useParams<{ typeId: string }>();
   const parsedConcertId = typeId ? Number(typeId) : 0;
-  const concertDetail = useConcertDetail(parsedConcertId);
+  const [isMoreButton, setIsMoreButton] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-
+  const concertDetail = useConcertDetail(parsedConcertId);
   const { concert } = concertDetail;
 
   const toggleExpanded = () => {
     setIsExpanded((prev) => !prev);
   };
+
+  console.log(concertDetail.concertArtists);
+
+  useEffect(() => {
+    if (concertDetail.concertArtists.length >= 4) {
+      setIsMoreButton(true);
+    }
+  }, [concertDetail.concertArtists.length]);
 
   return (
     <>
@@ -59,7 +67,11 @@ const ConcertDetailPage = () => {
       />
       <Spacing />
       <ArtistTitle />
-      <ArtistSection type="concert" artistData={concertDetail} />
+      <ArtistSection
+        type="concert"
+        artistData={concertDetail}
+        isMoreButton={isMoreButton}
+      />
       <FloatingButton />
       <Footer />
     </>

--- a/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
+++ b/packages/design-system/src/components/ticketing-carousel/ticketing-carousel.css.ts
@@ -60,6 +60,8 @@ export const description = style({
   position: 'absolute',
   top: '1.6rem',
   width: '80%',
+  wordBreak: 'keep-all',
+  whiteSpace: 'pre-line',
 });
 
 export const infoDday = style({


### PR DESCRIPTION
## 📌 Summary

* #293 

## 📚 Tasks

* 콘서트 페이지에서 상태하나 추가해서 prop depth 1로 뚫어놨습니다. 
* 하단 배너 줄 바꿈 UI도 수정하였어요 
* 일단 급하게 짠 로직이라 어설픈게 많아요 추후 리팩토링 필요합니다.


## 👀 To Reviewer

콘서트 페이지에서 아티스트가 4명 이상일 때에만 더보기 버튼이 보이도록 수정하였습니다.

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요. 필요시 .gif 형식으로 첨부해주세요.
-->
